### PR TITLE
Automatically Add Civilian Factions to Excluded Factions List

### DIFF
--- a/asr_ai3/addons/main/initSettings.sqf
+++ b/asr_ai3/addons/main/initSettings.sqf
@@ -8,7 +8,7 @@
     {
         GVAR(skip_factions) = call compile GVAR(factionskip_str);
 
-		private _civFactions = ("(getNumber (_x >> 'side')) == 3" configClasses (configFile >> "CfgFactionClasses")) apply {configName _x};
-		GVAR(skip_factions) append _civFactions;
+        private _civFactions = ("(getNumber (_x >> 'side')) == 3" configClasses (configFile >> "CfgFactionClasses")) apply {configName _x};
+        GVAR(skip_factions) append _civFactions;
     }
 ] call CBA_Settings_fnc_init;

--- a/asr_ai3/addons/main/initSettings.sqf
+++ b/asr_ai3/addons/main/initSettings.sqf
@@ -3,9 +3,12 @@
     "EDITBOX",
     "AI scripts excluded factions",
     "ASR AI3",
-    "['CIV_F','CIV_IDAP_F','LOP_AFR_Civ','LOP_CHR_Civ','LOP_TAK_Civ']",
+    "['LOP_AFR_Civ','LOP_CHR_Civ','LOP_TAK_Civ']",
     1,
     {
         GVAR(skip_factions) = call compile GVAR(factionskip_str);
+
+		private _civFactions = ("(getNumber (_x >> 'side')) == 3" configClasses (configFile >> "CfgFactionClasses")) apply {configName _x};
+		GVAR(skip_factions) append _civFactions;
     }
 ] call CBA_Settings_fnc_init;


### PR DESCRIPTION
Pretty much what the title says. This way any mod's civilians will be compatible by default. I left the LOP factions in there so people who want to change the setting can still see the array format.