### PR TITLE
Fix TakeEH Performance issue

### DIFF
--- a/asr_ai3/addons/skills/fnc_setUnitCamo.sqf
+++ b/asr_ai3/addons/skills/fnc_setUnitCamo.sqf
@@ -13,7 +13,7 @@ private _gearItems = [_uniform, _vest, _ruck]; //uni must be checked first for g
 
 //Don't do anything if the relevant items didn't change
 if (_unit getVariable ["asr_ai_skills_camoCache", []] isEqualTo [_gearItems, _tube]) exitWith {};
-unit setVariable ["asr_ai_skills_camoCache", [_gearItems, _tube]];
+_unit setVariable ["asr_ai_skills_camoCache", [_gearItems, _tube], false];
 
 private _rootclasses = ["CfgWeapons", "CfgWeapons", "CfgVehicles"];
 private _camo = 0;

--- a/asr_ai3/addons/skills/fnc_setUnitCamo.sqf
+++ b/asr_ai3/addons/skills/fnc_setUnitCamo.sqf
@@ -7,12 +7,13 @@ if !(local _unit) exitWith {};
 private _uniform = uniform _unit;
 private _vest = vest _unit;
 private _ruck = backpack _unit;
+private _tube = secondaryWeapon _unit;
 
 private _gearItems = [_uniform, _vest, _ruck]; //uni must be checked first for ghillie special case
 
 //Don't do anything if the relevant items didn't change
-if (_unit getVariable ["asr_ai_skills_camoCache", []] isEqualTo _gearItems) exitWith {};
-unit setVariable ["asr_ai_skills_camoCache", _gearItems];
+if (_unit getVariable ["asr_ai_skills_camoCache", []] isEqualTo [_gearItems, _tube]) exitWith {};
+unit setVariable ["asr_ai_skills_camoCache", [_gearItems, _tube]];
 
 private _rootclasses = ["CfgWeapons", "CfgWeapons", "CfgVehicles"];
 private _camo = 0;
@@ -30,7 +31,7 @@ private _pieces = 0;
 } forEach _gearItems;
 
 // launcher on back gives one up, the more the bigger it is.
-private _tube = secondaryWeapon _unit;
+
 private _tubeCoef = 1;
 if (_tube != "" && {isClass (configfile>>"CfgWeapons">>_tube)}) then {
     private _tubemass = [configfile>>"CfgWeapons">>_tube>>"WeaponSlotsInfo">>"mass", "number", 0] call CBA_fnc_getConfigEntry;

--- a/asr_ai3/addons/skills/fnc_setUnitCamo.sqf
+++ b/asr_ai3/addons/skills/fnc_setUnitCamo.sqf
@@ -9,6 +9,11 @@ private _vest = vest _unit;
 private _ruck = backpack _unit;
 
 private _gearItems = [_uniform, _vest, _ruck]; //uni must be checked first for ghillie special case
+
+//Don't do anything if the relevant items didn't change
+if (_unit getVariable ["asr_ai_skills_camoCache", []] isEqualTo _gearItems) exitWith {};
+unit setVariable ["asr_ai_skills_camoCache", _gearItems];
+
 private _rootclasses = ["CfgWeapons", "CfgWeapons", "CfgVehicles"];
 private _camo = 0;
 private _pieces = 0;


### PR DESCRIPTION
I'm sure you remember the lag when trying to quickly move items from a container into your inventory or the other way around.

I didn't expect ASR_AI to be responsible for it. But apparently it is.

![brofiler_2018-04-09_14-18-00](https://user-images.githubusercontent.com/3768165/38497415-543c5502-3c01-11e8-8ea0-948660db41b4.png)

It doesn't make sense to update the camouflage coefficient if all I did was take a ACE bandage out of a box.
