### PR TITLE
Small perf optimization on skills_fnc_unitNVG

### DIFF
--- a/asr_ai3/addons/skills/fnc_unitNVG.sqf
+++ b/asr_ai3/addons/skills/fnc_unitNVG.sqf
@@ -8,10 +8,11 @@ if (_nvg != "") exitWith {[_nvg, ""]}; //quick way out
 
 private _helmet = headGear _unit;
 private _nvgHelmet = "";
+if (_helmet == "") exitWith {["",""]};
 
-if (_helmet != "") then {
-    private _subItems = [(configFile>>"CfgWeapons">>_helmet), "subItems", []] call BIS_fnc_returnConfigEntry;
-    { if (getText(configFile>>"CfgWeapons">>_x>>"simulation") == "NVGoggles") exitWith {_nvgHelmet = _helmet} } forEach _subItems;
-};
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _subItems = getArray _cfgWeapons >> _helmet >> "subItems";
+private _found = _subItems findIf {getText(_cfgWeapons >> _x >> "simulation") == "NVGoggles"};
+if (_found == -1) exitWith {["",""]};
 
-["", _nvgHelmet]
+["", _helmet]


### PR DESCRIPTION
Tested with the Viper helmet with integrated NVG
Old: 107.661702us
New: 36.441649us

About 66% faster

If you wanna ask why I do this:
![](https://s.sqf.ovh/Brofiler_2018-10-26_15-35-26.png)
You showed up on my profiler. No one shows up on my profiler and comes out unscathed!!!