### PR TITLE
fnc_isValidUnit perf optimization

### DIFF
--- a/asr_ai3/addons/main/fnc_isValidUnit.sqf
+++ b/asr_ai3/addons/main/fnc_isValidUnit.sqf
@@ -1,3 +1,3 @@
 //#define DEBUG_MODE_FULL
 #include "script_component.hpp"
-!(isNull _this) && {alive _this} && {(GVAR(skip_factions) select {_x == faction _this}) isEqualTo []} && {!(_this getVariable ["asr_ai_exclude", false])}
+!(isNull _this) && {alive _this} && {(GVAR(skip_factions) find (faction _this)) == -1} && {!(_this getVariable ["asr_ai_exclude", false])}


### PR DESCRIPTION
This makes `skip_factions` case-sensitive though.
Is that important that it stays case-insensitive? Then one could use
```
private _fac = faction _this;
(GVAR(skip_factions) findIf {_x == _fac}) == -1
```


Old: 28.6163us
find: 6.11624us
findIf: 17.1003us