### PR TITLE
perf opt fnc_showHideNVG

### DIFF
--- a/asr_ai3/addons/skills/fnc_showHideNVG.sqf
+++ b/asr_ai3/addons/skills/fnc_showHideNVG.sqf
@@ -8,7 +8,12 @@ if (_show) then { // Equip NVG
 	if (_nvg != "" || _nvgHelmet != "") exitWith {
 		LOG("Already has NVG equipped");
 	};
-	{ if (getText(configFile>>"CfgWeapons">>_x>>"simulation") == "NVGoggles") exitWith {_nvg = _x} } forEach items _unit;
+	private _unitItems = [_unit] call CBA_fnc_uniqueUnitItems;
+	private _cfgWeapons = configFile >> "CfgWeapons";
+	
+	private _found = _unitItems findIf {getText (_cfgWeapons >> _x >> "simulation") == "NVGoggles"};
+	if (_found != -1) then {_nvg = _unitItems select _found;};
+
 	if (_nvg != "") then {
 		_unit assignItem _nvg;
 		TRACE_2("Unit equips NVG",_unit,_nvg);

--- a/asr_ai3/addons/skills/fnc_showHideNVG.sqf
+++ b/asr_ai3/addons/skills/fnc_showHideNVG.sqf
@@ -8,10 +8,8 @@ if (_show) then { // Equip NVG
 	if (_nvg != "" || _nvgHelmet != "") exitWith {
 		LOG("Already has NVG equipped");
 	};
-	private _unitItems = [_unit] call CBA_fnc_uniqueUnitItems;
-	private _cfgWeapons = configFile >> "CfgWeapons";
-	
-	private _found = _unitItems findIf {getText (_cfgWeapons >> _x >> "simulation") == "NVGoggles"};
+	private _unitItems = [_unit, false, true, true, true, false] call CBA_fnc_uniqueUnitItems;
+	private _found = _unitItems findIf {getText (configFile >> "CfgWeapons" >> _x >> "simulation") isEqualTo "NVGoggles"};
 	if (_found != -1) then {_nvg = _unitItems select _found;};
 
 	if (_nvg != "") then {

--- a/asr_ai3/addons/skills/fnc_showHideNVG.sqf
+++ b/asr_ai3/addons/skills/fnc_showHideNVG.sqf
@@ -9,7 +9,8 @@ if (_show) then { // Equip NVG
 		LOG("Already has NVG equipped");
 	};
 	private _unitItems = [_unit, false, true, true, true, false] call CBA_fnc_uniqueUnitItems;
-	private _found = _unitItems findIf {getText (configFile >> "CfgWeapons" >> _x >> "simulation") isEqualTo "NVGoggles"};
+	private _cfgWeapons = configFile >> "CfgWeapons";
+	private _found = _unitItems findIf {getText (_cfgWeapons >> _x >> "simulation") isEqualTo "NVGoggles"};
 	if (_found != -1) then {_nvg = _unitItems select _found;};
 
 	if (_nvg != "") then {


### PR DESCRIPTION
This is a really controversial change..
Iterating through `items _unit` can end VERY badly.

Without a backpack:
Old: 35.3315us
New: 157.935us

With a backpack full of ACE bandages:
Old: 2951.2us
New: 170.588us

Old code scales up with amount of items in inventory. New code doesn't.

Alternative
```
private _items = (items _unit);
{ if (getText(configFile>>"CfgWeapons">>_x>>"simulation") == "NVGoggles") exitWith {_nvg = _x} } forEach (_items arrayIntersect _items);
```
Without backpack: 25.463us
With backpack: 279.848us

Still scales up. But the effect at the few-items-in-inventory end isn't as dramatic.


Or another alternative. Make your own specialized variant of CBA_fnc_uniqueUnitItems
```
private _allItems = assignedItems _unit; 
_allItems append ((getItemCargo (uniformContainer _unit)) select 0); 
_allItems append ((getItemCargo (vestContainer _unit)) select 0); 
_allItems append ((getItemCargo (backpackContainer _unit)) select 0);


_allItems arrayIntersect _allItems
```

Using that instead of calling the CBA func:
without backpack: 74.1513us
with backpack: 123.623us